### PR TITLE
Update python-igraph dependency to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 	"pandas",
 	"scipy",
 	"psutil",
-	"python-igraph",
+	"igraph",
 	"longestrunsubsequence",
 	"pulp",
 ]


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for an explanation. The renaming applies only to PyPI, not Conda.