### PR TITLE
remove python version bound

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - python >=3.8,<=3.10
+    - python >=3.8
     - setuptools
     - numpy >=1.21.2
     # Please review cython pinning on future releases
@@ -28,7 +28,7 @@ requirements:
     - cython
     - libxcrypt
   run:
-    - python >=3.8,<=3.10
+    - python >=3.8
     - numpy >=1.21.2
     - pandas >=1.2.4
     - scipy >=1.6.2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Is the commit message clear and explains what the PR does?
- [X] Is the PR tested?
- [ ] Are tests for the changes available and added (for bug fixes / features)
- [ ] If needed, docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Removes the version bound to `python 3.10` in the syri conda recipe.
Syri works fine with `python 3.12.7`, I think the reason for the bound was originally because `pysam` did not support recent versions of python.


* **What is the current behavior?** (You can also link to an open issue here)
Conda in some cases gives a mistake trying to install syri to an env with `python > 3.10` installed.


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
