### PR TITLE
Remove double datetime printing in logging

### DIFF
--- a/syri/pyxFiles/synsearchFunctions.pyx
+++ b/syri/pyxFiles/synsearchFunctions.pyx
@@ -8,7 +8,6 @@ from syri.scripts.func import *
 import sys
 from collections import deque, defaultdict
 # from scipy.stats import *
-from datetime import datetime
 import pandas as pd
 from multiprocessing import Pool
 from functools import partial
@@ -622,7 +621,7 @@ def syri(chromo, threshold, coords, cwdPath, bRT, prefix, tUC, tUP, invgl, tdgl,
     for i in range(len(allTransCluster)):
         allTransClusterIndices.update(dict.fromkeys(allTransCluster[i], i))
 
-    logger.debug("Translocations : making blocks data " + chromo +" " + str(datetime.now()))
+    logger.debug("Translocations : making blocks data " + chromo)
     logger.debug("memory usage: " + str(psutil.Process(os.getpid()).memory_info()[0]/2.**30))
 
     if len(allTransBlocks) > 0:
@@ -709,7 +708,7 @@ def syri(chromo, threshold, coords, cwdPath, bRT, prefix, tUC, tUP, invgl, tdgl,
         # del(aUni, bUni, status, aIndex, bIndex, aGroups, bGroups, out)
         # collect()
 
-    logger.debug("Translocations : finding solutions "+ chromo + str(datetime.now()))
+    logger.debug("Translocations : finding solutions "+ chromo)
     clusterSolutions = []
     for i in range(len(allTransCluster)):
         if len(allTransCluster[i]) > 0:
@@ -721,7 +720,7 @@ def syri(chromo, threshold, coords, cwdPath, bRT, prefix, tUC, tUP, invgl, tdgl,
     clusterSolutionBlocks = [i[1] for i in clusterSolutions]
     #clusterBlocks = unlist(clusterSolutionBlocks)
 
-    logger.debug("Translocations : processing translocations " + chromo + str(datetime.now()))
+    logger.debug("Translocations : processing translocations " + chromo)
 
     garb = deque()
     for i in range(len(allTransBlocksData)):

--- a/syri/pyxFiles/tdfunc.pyx
+++ b/syri/pyxFiles/tdfunc.pyx
@@ -4,7 +4,6 @@
 import pandas as pd
 import numpy as np
 from collections import deque
-from datetime import datetime
 import logging
 import time
 from syri.scripts.func import unlist, getValues, intersect
@@ -481,7 +480,7 @@ def readAnnoCoords(cwdPath, uniChromo, prefix):
 
 def getCTX(coords, cwdPath, uniChromo, threshold, bRT, prefix, tUC, tUP, nCores, tdgl, tdolp):
     logger = logging.getLogger("getCTX")
-    logger.info("Identifying cross-chromosomal translocation and duplication for chromosome" + str(datetime.now()))
+    logger.info("Identifying cross-chromosomal translocation and duplication for chromosome")
 
     def getDupCTX(indices, allTransBlocksData, transClasses, astart, aend, bstart, bend, aindex, bindex, agroup, bgroup, threshold, meclass, tdolp):
         dupGenomes = {}
@@ -516,7 +515,7 @@ def getCTX(coords, cwdPath, uniChromo, threshold, bRT, prefix, tUC, tUP, nCores,
                 dupGenomes[index] = "A"
         return(dupGenomes)
 
-    logger.debug("Reading Coords" + str(datetime.now()))
+    logger.debug("Reading Coords")
 
     annoCoords = readAnnoCoords(cwdPath, uniChromo, prefix)
     ctxData = coords.loc[coords['aChr'] != coords['bChr']].copy()
@@ -1050,7 +1049,6 @@ cpdef getProfitableTrans(cpp_map[long, cpp_set[long]] graph, long[:] astart, lon
         dist[i] = 0
 
         # Process vertices in topological order
-        st = datetime.now()
         a = deque()
         a.append(i)
         for k in range(edgecnt):
@@ -1059,7 +1057,6 @@ cpdef getProfitableTrans(cpp_map[long, cpp_set[long]] graph, long[:] astart, lon
                 dist[target[k]] = dist[source[k]] + weight[k]
                 pred[target[k]] = source[k]
 
-        st = datetime.now()
         cnt = 0
         #for j in n:
         for j in set(a):


### PR DESCRIPTION
Tiny PR to remove cases where the datestring was included in the logging message as well as in the logging output.
Tested locally, doesn't affect anything but logging code anyway.